### PR TITLE
Switch docs to RTD theme

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -15,6 +15,18 @@
 import sys
 import os
 
+import sphinx_rtd_theme
+
+from mock import Mock as MagicMock
+class Mock(MagicMock):
+    @classmethod
+    def __getattr__(cls, name):
+        return Mock()
+
+# TODO: un-mock OPS as soon as we have working OPS conda
+MOCK_MODULES = ['numpy', 'openpathsampling']
+sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
+
 # If extensions (or modules to document with autodoc) are in another directory,
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
@@ -134,7 +146,10 @@ todo_include_todos = False
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'alabaster'
+# html_theme = 'alabaster'
+
+html_theme = 'sphinx_rtd_theme'
+html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The alabaster theme is ugly. RTD looks better, especially on the RTD website!
