### PR TITLE
Add ability to use 1-way segments as input to pseudo-simulator

### DIFF
--- a/ops_piggybacker/mover_stubs.py
+++ b/ops_piggybacker/mover_stubs.py
@@ -104,7 +104,8 @@ class ShootingStub(paths.pathmover.PathMover):
                                                  shooting_point,
                                                  direction)
 
-        # determine the direction
+        # determine the direction based on trial trajectory (maybe check
+        # with given direction if given?)
         shared = trial_trajectory.shared_subtrajectory(initial_trajectory)
         if shared[0] == trial_trajectory[0]:
             choice = 0  # forward submover

--- a/ops_piggybacker/mover_stubs.py
+++ b/ops_piggybacker/mover_stubs.py
@@ -39,14 +39,13 @@ class ShootingStub(paths.pathmover.PathMover):
         paths.Trajectory
             the complete trial trajectory
         """
-        initial_trajectory = input_sample.trajectory
-        shooting_idx = initial_trajectory.index(shooting_point)
+        shooting_idx = input_trajectory.index(shooting_point)
         if direction > 0:
-            joined_trajectory = (initial_trajectory[:shooting_idx+1] +
+            joined_trajectory = (input_trajectory[:shooting_idx+1] +
                                  partial_trial)
         elif direction < 0:
             joined_trajectory = (partial_trial +
-                                 initial_trajectory[shooting_idx:])
+                                 input_trajectory[shooting_idx:])
         else:
             raise RuntimeError("Bad direction for shooting: " +
                                str(direction))

--- a/ops_piggybacker/mover_stubs.py
+++ b/ops_piggybacker/mover_stubs.py
@@ -46,7 +46,7 @@ class ShootingStub(paths.pathmover.PathMover):
         elif direction < 0:
             joined_trajectory = (partial_trial +
                                  input_trajectory[shooting_idx:])
-        else:
+        else: # pragma: no cover
             raise RuntimeError("Bad direction for shooting: " +
                                str(direction))
         return joined_trajectory
@@ -76,11 +76,10 @@ class ShootingStub(paths.pathmover.PathMover):
         ensemble = input_sample.ensemble
 
         if not self.pre_joined:
-            initial_trajectory = self.join_one_way(input_trajectory,
-                                                   trial_trajectory,
-                                                   shooting_point,
-                                                   direction)
-            
+            trial_trajectory = self.join_one_way(initial_trajectory,
+                                                 trial_trajectory,
+                                                 shooting_point,
+                                                 direction)
 
         # determine the direction
         shared = trial_trajectory.shared_subtrajectory(initial_trajectory)

--- a/ops_piggybacker/mover_stubs.py
+++ b/ops_piggybacker/mover_stubs.py
@@ -4,6 +4,29 @@ class NoEngine(paths.engines.DynamicsEngine):
     pass
 
 class ShootingStub(paths.pathmover.PathMover):
+    """Stub to mimic a shooting move.
+    
+    Parameters
+    ----------
+    ensemble : paths.Ensemble
+        the ensemble for the shooting mover
+    selector : paths.ShootingPointSelector or None
+        the selector for the shooting point. Default None creates a
+        UniformSelector. Currently, only UniformSelector is supported.
+    engine : paths.engines.DynamicsEngine
+        the engine to report as the source of the dynamics
+    pre_joined : bool
+        whether the input trial trajectories are pre-joined into complete
+        trajectories, or take partial one-way segments which should by
+        dynamically joined. Currently defaults to pre_joined=True (likely to
+        change soon, though)
+
+    Attributes
+    ----------
+    mimic : paths.OneWayShootingMover
+        the mover that this stub mimics
+
+    """
     def __init__(self, ensemble, selector=None, engine=None, pre_joined=True):
         super(ShootingStub, self).__init__()
         if engine is None:

--- a/ops_piggybacker/simulation_stubs.py
+++ b/ops_piggybacker/simulation_stubs.py
@@ -1,6 +1,19 @@
 import openpathsampling as paths
 
 class ShootingPseudoSimulator(paths.PathSimulator):
+    """Pseudo-simulator for shooting-only mimics.
+
+    Parameters
+    ----------
+    storage : openpathsampling.netcdfplus.Storage
+        file to store OPS-ready analysis
+    initial_conditions : openpathsampling.SampleSet
+        sample set giving the OPS version of the initial conditions
+    mover : ShootingStub
+        stub to mimic the shooting mover
+    network : openpathsampling.TransitionNetwork
+        transition network with information about this system
+    """
     def __init__(self, storage, initial_conditions, mover, network):
         super(ShootingPseudoSimulator, self).__init__(storage)
         self.scheme = paths.LockedMoveScheme(mover, network)

--- a/ops_piggybacker/simulation_stubs.py
+++ b/ops_piggybacker/simulation_stubs.py
@@ -19,7 +19,9 @@ class ShootingPseudoSimulator(paths.PathSimulator):
         Parameters
         ----------
         step_info_list : list of tuple
-            (replica, trial_trajectory, shooting_point_index, accepted)
+            (replica, trial_trajectory, shooting_point_index, accepted) or
+            (replica, one_way_trial_segment, shooting_point_index, accepted,
+            direction)
         """
         mcstep = None
 
@@ -30,17 +32,27 @@ class ShootingPseudoSimulator(paths.PathSimulator):
 
         for step_info in step_info_list:
             self.step += 1
+            if len(step_info) == 4 and not self.mover.pre_joined:
+                raise RuntimeError(
+                    "Shooting trial trajectories not pre-joined: " + 
+                    "step_info must be (replica, trial_segment, " + 
+                    "shooting_pt_idx, accepted, direction)")
             
             replica = step_info[0]
             trial_trajectory = step_info[1]
             shooting_point_index = step_info[2]
             accepted = step_info[3]
+            direction = None
+            if len(step_info) == 5:
+                direction = step_info[4]
 
             input_sample = self.globalstate[replica]
             shooting_point = input_sample.trajectory[shooting_point_index]
 
+
+
             subchange = self.mover.move(input_sample, trial_trajectory,
-                                        shooting_point, accepted)
+                                        shooting_point, accepted, direction)
 
             change = paths.PathSimulatorPathMoveChange(
                 subchange=subchange,

--- a/ops_piggybacker/simulation_stubs.py
+++ b/ops_piggybacker/simulation_stubs.py
@@ -32,7 +32,7 @@ class ShootingPseudoSimulator(paths.PathSimulator):
 
         for step_info in step_info_list:
             self.step += 1
-            if len(step_info) == 4 and not self.mover.pre_joined:
+            if len(step_info) == 4 and not self.mover.pre_joined: # pragma: no-cover
                 raise RuntimeError(
                     "Shooting trial trajectories not pre-joined: " + 
                     "step_info must be (replica, trial_segment, " + 
@@ -48,7 +48,6 @@ class ShootingPseudoSimulator(paths.PathSimulator):
 
             input_sample = self.globalstate[replica]
             shooting_point = input_sample.trajectory[shooting_point_index]
-
 
 
             subchange = self.mover.move(input_sample, trial_trajectory,

--- a/ops_piggybacker/tests/common_test_data.py
+++ b/ops_piggybacker/tests/common_test_data.py
@@ -28,12 +28,13 @@ def shooting_move_info():
 
     # for traj in [t0, out1, out2, out3, out4]:
         # print [s.xyz[0][0] for s in traj]
-
+    
+    # replica, full trial, shooting idx, one-way trial, direction
     moves = [
-        (0, out1, 4, True),
-        (0, out2, 2, True),
-        (0, out3, 5, False),
-        (0, out4, 4, True)
+        (0, out1, 4, True, t1, -1),
+        (0, out2, 2, True, t2, +1),
+        (0, out3, 5, False, t3, -1),
+        (0, out4, 4, True, t4, +1)
     ]
     initial_sample = paths.Sample(replica=0,
                                   trajectory=t0,

--- a/ops_piggybacker/tests/common_test_data.py
+++ b/ops_piggybacker/tests/common_test_data.py
@@ -34,7 +34,7 @@ def shooting_move_info():
         (0, out1, 4, True, t1, -1),
         (0, out2, 2, True, t2, +1),
         (0, out3, 5, False, t3, -1),
-        (0, out4, 4, True, t4, +1)
+        (0, out4, 4, True, t4, -1)
     ]
     initial_sample = paths.Sample(replica=0,
                                   trajectory=t0,

--- a/ops_piggybacker/tests/test_mover_stubs.py
+++ b/ops_piggybacker/tests/test_mover_stubs.py
@@ -15,6 +15,9 @@ class testShootingStub(object):
         # this instantiates an object, and ensures that instantiation works
         self.stub = oink.ShootingStub(common.tps_ensemble)
 
+    def test_join_one_way(self):
+        raise SkipTest
+
     def test_backward_move(self):
         initial_sample = common.initial_tps_sample
         move = common.tps_shooting_moves[0]
@@ -36,6 +39,9 @@ class testShootingStub(object):
         # assertions specific to this test
         assert_equal(change.accepted, True)
         assert_equal(type(change.canonical.mover), paths.BackwardShootMover)
+
+    def test_backward_move_not_pre_joined(self):
+        raise SkipTest
 
     def test_forward_move(self):
         init_traj = common.tps_shooting_moves[0][1]
@@ -62,6 +68,9 @@ class testShootingStub(object):
         assert_equal(change.accepted, True)
         assert_equal(type(change.canonical.mover), paths.ForwardShootMover)
 
+    def test_forward_move_not_pre_joined(self):
+        raise SkipTest
+
     def test_rejected_move(self):
         initial_sample = common.initial_tps_sample
         move = common.tps_shooting_moves[0]
@@ -83,3 +92,6 @@ class testShootingStub(object):
         # assertions specific to this test
         assert_equal(change.accepted, False)
         assert_equal(type(change.canonical.mover), paths.BackwardShootMover)
+
+    def test_rejected_move_not_pre_joined(self):
+        raise SkipTest

--- a/ops_piggybacker/tests/test_mover_stubs.py
+++ b/ops_piggybacker/tests/test_mover_stubs.py
@@ -42,10 +42,10 @@ class testShootingStub(object):
         joined_3 = self.no_prejoin.join_one_way(joined_2, trial_3, sp_3, dir_3)
         assert_equal(joined_3, out_3)
 
-        out_4 = moves[2][1]
-        sp_4 = joined_2[moves[2][2]]
-        trial_4 = moves[2][4]
-        dir_4 = moves[2][5]
+        out_4 = moves[3][1]
+        sp_4 = joined_2[moves[3][2]]
+        trial_4 = moves[3][4]
+        dir_4 = moves[3][5]
         joined_4 = self.no_prejoin.join_one_way(joined_2, trial_4, sp_4, dir_4)
         assert_equal(joined_4, out_4)
 

--- a/ops_piggybacker/tests/test_mover_stubs.py
+++ b/ops_piggybacker/tests/test_mover_stubs.py
@@ -16,7 +16,36 @@ class testShootingStub(object):
         self.stub = oink.ShootingStub(common.tps_ensemble)
 
     def test_join_one_way(self):
-        raise SkipTest
+        moves = common.tps_shooting_moves
+        initial = common.initial_tps_sample.trajectory
+        
+        out_1 = moves[0][1]
+        sp_1 = initial[moves[0][2]]
+        trial_1 = moves[0][4]
+        dir_1 = moves[0][5]
+        joined_1 = self.stub.join_one_way(initial, trial_1, sp_1, dir_1)
+        assert_equal(joined_1, out_1)
+
+        out_2 = moves[1][1]
+        sp_2 = joined_1[moves[1][2]]
+        trial_2 = moves[1][4]
+        dir_2 = moves[1][5]
+        joined_2 = self.stub.join_one_way(joined_1, trial_2, sp_2, dir_2)
+        assert_equal(joined_2, out_2)
+
+        out_3 = moves[2][1]
+        sp_3 = joined_2[moves[2][2]]
+        trial_3 = moves[2][4]
+        dir_3 = moves[2][5]
+        joined_3 = self.stub.join_one_way(joined_2, trial_3, sp_3, dir_3)
+        assert_equal(joined_3, out_3)
+
+        out_4 = moves[2][1]
+        sp_4 = joined_2[moves[2][2]]
+        trial_4 = moves[2][4]
+        dir_4 = moves[2][5]
+        joined_4 = self.stub.join_one_way(joined_2, trial_4, sp_4, dir_4)
+        assert_equal(joined_4, out_4)
 
     def test_backward_move(self):
         initial_sample = common.initial_tps_sample

--- a/ops_piggybacker/tests/test_mover_stubs.py
+++ b/ops_piggybacker/tests/test_mover_stubs.py
@@ -14,6 +14,8 @@ class testShootingStub(object):
     def setup(self):
         # this instantiates an object, and ensures that instantiation works
         self.stub = oink.ShootingStub(common.tps_ensemble)
+        self.no_prejoin = oink.ShootingStub(common.tps_ensemble,
+                                            pre_joined=False)
 
     def test_join_one_way(self):
         moves = common.tps_shooting_moves
@@ -23,28 +25,28 @@ class testShootingStub(object):
         sp_1 = initial[moves[0][2]]
         trial_1 = moves[0][4]
         dir_1 = moves[0][5]
-        joined_1 = self.stub.join_one_way(initial, trial_1, sp_1, dir_1)
+        joined_1 = self.no_prejoin.join_one_way(initial, trial_1, sp_1, dir_1)
         assert_equal(joined_1, out_1)
 
         out_2 = moves[1][1]
         sp_2 = joined_1[moves[1][2]]
         trial_2 = moves[1][4]
         dir_2 = moves[1][5]
-        joined_2 = self.stub.join_one_way(joined_1, trial_2, sp_2, dir_2)
+        joined_2 = self.no_prejoin.join_one_way(joined_1, trial_2, sp_2, dir_2)
         assert_equal(joined_2, out_2)
 
         out_3 = moves[2][1]
         sp_3 = joined_2[moves[2][2]]
         trial_3 = moves[2][4]
         dir_3 = moves[2][5]
-        joined_3 = self.stub.join_one_way(joined_2, trial_3, sp_3, dir_3)
+        joined_3 = self.no_prejoin.join_one_way(joined_2, trial_3, sp_3, dir_3)
         assert_equal(joined_3, out_3)
 
         out_4 = moves[2][1]
         sp_4 = joined_2[moves[2][2]]
         trial_4 = moves[2][4]
         dir_4 = moves[2][5]
-        joined_4 = self.stub.join_one_way(joined_2, trial_4, sp_4, dir_4)
+        joined_4 = self.no_prejoin.join_one_way(joined_2, trial_4, sp_4, dir_4)
         assert_equal(joined_4, out_4)
 
     def test_backward_move(self):
@@ -70,7 +72,27 @@ class testShootingStub(object):
         assert_equal(type(change.canonical.mover), paths.BackwardShootMover)
 
     def test_backward_move_not_pre_joined(self):
-        raise SkipTest
+        initial_sample = common.initial_tps_sample
+        move = common.tps_shooting_moves[0]
+        replica = move[0]
+        trial_trajectory = move[4]
+        shooting_point = initial_sample.trajectory[move[2]]
+        accepted = move[3]
+        direction = move[5]
+        change = self.no_prejoin.move(initial_sample, trial_trajectory,
+                                      shooting_point, accepted, direction)
+        # assertions about the shape of the decision history
+        assert_equal(change.mover, self.no_prejoin.mimic)
+        assert_equal(change.subchange, change.canonical)
+        assert_equal(change.subchange.subchange, None)
+        assert_equal(len(change.trials), 1)
+        # assertions true for any OneWayShooting
+        details0 = change.canonical.trials[0].details
+        assert_equal(details0.shooting_snapshot, shooting_point)
+        assert_equal(details0.initial_trajectory.index(shooting_point), move[2])
+        # assertions specific to this test
+        assert_equal(change.accepted, True)
+        assert_equal(type(change.canonical.mover), paths.BackwardShootMover)
 
     def test_forward_move(self):
         init_traj = common.tps_shooting_moves[0][1]
@@ -98,7 +120,30 @@ class testShootingStub(object):
         assert_equal(type(change.canonical.mover), paths.ForwardShootMover)
 
     def test_forward_move_not_pre_joined(self):
-        raise SkipTest
+        init_traj = common.tps_shooting_moves[0][1]
+        initial_sample = paths.Sample(replica=0,
+                                      trajectory=init_traj,
+                                      ensemble=common.tps_ensemble)
+        move = common.tps_shooting_moves[1]
+        replica = move[0]
+        trial_trajectory = move[4]
+        shooting_point = initial_sample.trajectory[move[2]]
+        accepted = move[3]
+        direction = move[5]
+        change = self.no_prejoin.move(initial_sample, trial_trajectory,
+                                      shooting_point, accepted, direction)
+        # assertions about the shape of the decision history
+        assert_equal(change.mover, self.no_prejoin.mimic)
+        assert_equal(change.subchange, change.canonical)
+        assert_equal(change.subchange.subchange, None)
+        assert_equal(len(change.trials), 1)
+        # assertions true for any OneWayShooting
+        details0 = change.canonical.trials[0].details
+        assert_equal(details0.shooting_snapshot, shooting_point)
+        assert_equal(details0.initial_trajectory.index(shooting_point), move[2])
+        # assertions specific to this test
+        assert_equal(change.accepted, True)
+        assert_equal(type(change.canonical.mover), paths.ForwardShootMover)
 
     def test_rejected_move(self):
         initial_sample = common.initial_tps_sample
@@ -123,4 +168,24 @@ class testShootingStub(object):
         assert_equal(type(change.canonical.mover), paths.BackwardShootMover)
 
     def test_rejected_move_not_pre_joined(self):
-        raise SkipTest
+        initial_sample = common.initial_tps_sample
+        move = common.tps_shooting_moves[0]
+        replica = move[0]
+        trial_trajectory = move[4]
+        shooting_point = initial_sample.trajectory[move[2]]
+        accepted = False
+        direction = move[5]
+        change = self.no_prejoin.move(initial_sample, trial_trajectory,
+                                      shooting_point, accepted, direction)
+        # assertions about the shape of the decision history
+        assert_equal(change.mover, self.no_prejoin.mimic)
+        assert_equal(change.subchange, change.canonical)
+        assert_equal(change.subchange.subchange, None)
+        assert_equal(len(change.trials), 1)
+        # assertions true for any OneWayShooting
+        details0 = change.canonical.trials[0].details
+        assert_equal(details0.shooting_snapshot, shooting_point)
+        assert_equal(details0.initial_trajectory.index(shooting_point), move[2])
+        # assertions specific to this test
+        assert_equal(change.accepted, False)
+        assert_equal(type(change.canonical.mover), paths.BackwardShootMover)

--- a/ops_piggybacker/tests/test_simulation_stubs.py
+++ b/ops_piggybacker/tests/test_simulation_stubs.py
@@ -37,9 +37,12 @@ class testShootingPseudoSimulator(object):
         if os.path.isfile(data_filename(self.fname)):
             os.remove(data_filename(self.fname))
 
+    def test_noprejoin_run_and_analyze(self):
+        raise SkipTest
 
     def test_run_and_analyze(self):
-        self.pseudosim.run(common.tps_shooting_moves)
+        moves = [tuple(move[0:4]) for move in common.tps_shooting_moves]
+        self.pseudosim.run(moves)
         self.storage.close()
         # open the file for analysis, check that its content is reasonable
         analysis = paths.AnalysisStorage(data_filename(self.fname))

--- a/ops_piggybacker/tests/test_simulation_stubs.py
+++ b/ops_piggybacker/tests/test_simulation_stubs.py
@@ -32,13 +32,55 @@ class testShootingPseudoSimulator(object):
             mover=shoot,
             network=network
         )
+
+        nojoin = oink.ShootingStub(tps_ensemble, pre_joined=False)
+        self.nojoin_pseudosim = oink.ShootingPseudoSimulator(
+            storage=self.storage,
+            initial_conditions=paths.SampleSet([initial_sample]),
+            mover=nojoin,
+            network=network
+        )
+
     
     def teardown(self):
         if os.path.isfile(data_filename(self.fname)):
             os.remove(data_filename(self.fname))
 
     def test_noprejoin_run_and_analyze(self):
-        raise SkipTest
+        moves = [(move[0], move[4], move[2], move[3], move[5]) 
+                 for move in common.tps_shooting_moves]
+        self.nojoin_pseudosim.run(moves)
+        self.storage.close()
+        # open the file for analysis, check that its content is reasonable
+        analysis = paths.AnalysisStorage(data_filename(self.fname))
+        assert_equal(len(analysis.steps), 5) # initial + 4 steps
+        scheme = analysis.schemes[0]
+        assert_equal(scheme.movers.keys(), ['shooting'])
+        assert_equal(len(scheme.movers['shooting']), 1)
+        mover = scheme.movers['shooting'][0]
+
+        # use several OPS tools to analyze this file
+        ## scheme.move_summary
+        devnull = open(os.devnull, 'w')
+        scheme.move_summary(analysis, output=devnull) 
+        mover_keys = [k for k in scheme._mover_acceptance.keys()
+                      if k[0] == mover]
+        assert_equal(len(mover_keys), 1)
+        assert_equal(scheme._mover_acceptance[mover_keys[0]], [3,4])
+
+        ## move history tree
+        import openpathsampling.visualize as ops_vis
+        history = ops_vis.ReplicaHistoryTree(
+            storage=analysis,
+            steps=analysis.steps[0:],
+            replica=0
+        )
+        assert_equal(len(history.decorrelated_trajectories), 2)
+
+        ## path length histogram
+        path_lengths = [len(step.active[0].trajectory) 
+                        for step in analysis.steps]
+        assert_equal(path_lengths, [11, 9, 7, 7, 7])
 
     def test_run_and_analyze(self):
         moves = [tuple(move[0:4]) for move in common.tps_shooting_moves]

--- a/ops_piggybacker/tests/tools.py
+++ b/ops_piggybacker/tests/tools.py
@@ -13,3 +13,8 @@ from pkg_resources import resource_filename
 def data_filename(fname, subdir='test_data'):
     return resource_filename('ops_piggybacker',
                              os.path.join('tests', subdir, fname))
+
+import logging
+logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.ensemble').setLevel(logging.CRITICAL)
+logging.getLogger('openpathsampling.initialization').setLevel(logging.CRITICAL)


### PR DESCRIPTION
This PR will add the ability to use the partial trajectories of 1-way shooting as inputs, instead of requiring full trial trajectories. This should make it significantly easier to import data from non-OPS simulations.

`ShootingStub` will takes a `pre_joined` argument on initialization, which defaults to `True` (the old behavior). If `False`, we assume that we’re using just the one-way shooting segments. In that case, the `ShootingStub` also needs a `direction` argument for each move. This must be given as extra information in the `move_info`.
- [x] Write `ShootingStub.join_one_way`
- [x] Test `ShootingStub.join_one_way`
- [x] Change `ShootingStub.move` to allow one-way input
- [x] Test `ShootingStub.move` with one-way input
- [x] Change `ShootingPseudoSimulator` to allow one-way input
- [x] Test `ShootingPseudoSimulator` with one-way input
- [x] Update docstrings
