### PR TITLE
Fix after OPS#508

### DIFF
--- a/ops_piggybacker/simulation_stubs.py
+++ b/ops_piggybacker/simulation_stubs.py
@@ -89,4 +89,4 @@ class ShootingPseudoSimulator(paths.PathSimulator):
 
             self.globalstate = new_sampleset
 
-        self.sync_storage
+        self.sync_storage()

--- a/ops_piggybacker/tests/test_simulation_stubs.py
+++ b/ops_piggybacker/tests/test_simulation_stubs.py
@@ -62,7 +62,7 @@ class testShootingPseudoSimulator(object):
         # use several OPS tools to analyze this file
         ## scheme.move_summary
         devnull = open(os.devnull, 'w')
-        scheme.move_summary(analysis, output=devnull) 
+        scheme.move_summary(analysis.steps, output=devnull) 
         mover_keys = [k for k in scheme._mover_acceptance.keys()
                       if k[0] == mover]
         assert_equal(len(mover_keys), 1)
@@ -97,7 +97,7 @@ class testShootingPseudoSimulator(object):
         # use several OPS tools to analyze this file
         ## scheme.move_summary
         devnull = open(os.devnull, 'w')
-        scheme.move_summary(analysis, output=devnull) 
+        scheme.move_summary(analysis.steps, output=devnull) 
         mover_keys = [k for k in scheme._mover_acceptance.keys()
                       if k[0] == mover]
         assert_equal(len(mover_keys), 1)


### PR DESCRIPTION
Tests were failing (even though the code was perfectly fine) following changes to the analysis routines in openpathsampling/openpathsampling#508.

Now the tests will pass again with the newest dev versions of OPS.
