### PR TITLE
Switch docs to conda-based

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ class Mock(MagicMock):
         return Mock()
 
 # TODO: un-mock OPS as soon as we have working OPS conda
-MOCK_MODULES = ['numpy', 'openpathsampling']
+MOCK_MODULES = ['numpy'] #, 'openpathsampling']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ class Mock(MagicMock):
         return Mock()
 
 # TODO: un-mock OPS as soon as we have working OPS conda
-MOCK_MODULES = ['numpy'] #, 'openpathsampling']
+MOCK_MODULES = []#['numpy'] #, 'openpathsampling']
 sys.modules.update((mod_name, Mock()) for mod_name in MOCK_MODULES)
 
 # If extensions (or modules to document with autodoc) are in another directory,

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -16,8 +16,13 @@ file that can use most of OPS's standard analysis tools.
 The current version, 0.1, only aims to cover one-way shooting moves in a
 single ensemble, as with TPS simulations. See the roadmap for future plans.
 
-Documentation
--------------
+Installation
+------------
+
+TODO
+
+Overview
+--------
 
 The overall approach is very similar to the setup of an OPS simulation.
 You use the standard OPS volume, collective variable, network, and ensemble
@@ -44,7 +49,28 @@ Once this is done, you simply use the :meth:`run
 :class:`.ShootingPseudoSimulator` to generate your file. However, whereas
 the run method of the ``PathSampling`` object in OPS takes an integer with a
 number of steps, in OPSPiggybacker, you must provide the output of your
-previous simulation to the run method of the pseudo-simulator. This is in
+previous simulation to the run method of the pseudo-simulator. The following
+subsection will describe the moves.
+
+Partial input trajectories
+--------------------------
+
+
+Full input trajectories
+-----------------------
+
+One of the input options for shooting moves is to use full input
+trajectories (``pre_joined=True``). In this case, the input trajectory must
+be an OPS format trajectory for the full trial trajectory. In addition,
+*the frames which are shared with other trajectories must be identical in
+memory frames.* Since this is quite hard to do, it is usually easier to use
+the ``pre_joined=False`` version with partial input trajectories.
+
+However, we full input trajectories, you don't need to specify whether a
+given trial was forward or backward: the OPSPiggybacker can figure that out
+for you.
+
+This is in
 the format of a list of 4-tuples ``(replica, trial_trajectory,
 shooting_point_index, accepted)``, where each 4-tuple represents a trial
 move. In detail, the elements of the tuple are:

--- a/ops_environment.yml
+++ b/ops_environment.yml
@@ -11,6 +11,7 @@ dependencies:
     - numpy
     - mdtraj
     - openssl
+    - openpathsampling-dev
     - pandas
     - pip
     - pycosat

--- a/ops_environment.yml
+++ b/ops_environment.yml
@@ -32,7 +32,3 @@ dependencies:
     - wheel
     - yaml
     - zlib
-    - pip:
-          - mdtraj
-          - ruamel-yaml-==VERSION
-          - tables

--- a/ops_environment.yml
+++ b/ops_environment.yml
@@ -1,0 +1,39 @@
+name: root
+channels:
+    - omnia
+    - http://conda.anaconda.org/omnia
+    - defaults
+dependencies:
+    - conda
+    - conda-env
+    - hdf5
+    - libgfortran
+    - mkl
+    - numexpr
+    - numpy
+    - omnia::mdtraj
+    - openssl
+    - pandas
+    - pip
+    - pycosat
+    - pycrypto
+    - pytables
+    - python
+    - python-dateutil
+    - pytz
+    - pyyaml
+    - readline
+    - requests
+    - ruamel_yaml
+    - scipy
+    - setuptools
+    - six
+    - sqlite
+    - tk
+    - wheel
+    - yaml
+    - zlib
+    - pip:
+          - mdtraj
+          - ruamel-yaml-==VERSION
+          - tables

--- a/ops_environment.yml
+++ b/ops_environment.yml
@@ -4,8 +4,6 @@ channels:
     - http://conda.anaconda.org/omnia
     - defaults
 dependencies:
-    - conda
-    - conda-env
     - hdf5
     - libgfortran
     - mkl

--- a/ops_environment.yml
+++ b/ops_environment.yml
@@ -11,7 +11,7 @@ dependencies:
     - mkl
     - numexpr
     - numpy
-    - omnia::mdtraj
+    - mdtraj
     - openssl
     - pandas
     - pip

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,0 +1,2 @@
+conda:
+    file: ops_environment.yml

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,2 +1,5 @@
 conda:
     file: ops_environment.yml
+python:
+    version: 2.7
+    setup_py_install: true


### PR DESCRIPTION
Switching to conda so we can get OPS inheritance included.
- [x] Get docs to build with successful install of OPS and its reqs
- [x] Get docs to include proper refs to OPS stuff
