### PR TITLE
Switch to building OPS from conda

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ script:
     #- source devtools/no-ops-conda/build.sh
     # the next three are preferred if the OPS conda build is working
     - conda build devtools/conda-recipe
-    - conda install --use-local dynamiq_samplers-dev
+    - conda install --use-local ops_piggybacker-dev
     - conda install nose python-coveralls
 
     - python -c "import openpathsampling; print 'OPS version' + openpathsampling.version.full_version"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,12 +12,12 @@ script:
     - conda install --yes conda-build
     - conda config --set always_yes true
     # the next two are if the OPS conda build isn't working
-    - source devtools/no-ops-conda/make_build.sh
-    - source devtools/no-ops-conda/build.sh
+    #- source devtools/no-ops-conda/make_build.sh
+    #- source devtools/no-ops-conda/build.sh
     # the next three are preferred if the OPS conda build is working
-    #- conda build devtools/conda-recipe
-    #- source activate _test
-    #- conda clean -pltis --yes
+    - conda build devtools/conda-recipe
+    - conda install --use-local dynamiq_samplers-dev
+    - conda install nose python-coveralls
 
     - python -c "import openpathsampling; print 'OPS version' + openpathsampling.version.full_version"
     - python ops_piggybacker/tests/common_test_data.py

--- a/devtools/conda-recipe/meta.yaml
+++ b/devtools/conda-recipe/meta.yaml
@@ -16,13 +16,8 @@ requirements:
         - numpy
         - scipy
         - pandas
-        - openpathsampling-dev
-
+        - openpathsampling
 
 test:
-    requires:
-        - nose
-        - python-coveralls
-
     imports:
         - ops_piggybacker


### PR DESCRIPTION
Now that we have a 0.9.0 release of OPS that _can_ be built by conda, let's use it.

From now on, the Piggybacker is tied to the most recent _release_ of OPS, not the most recent _dev_ build.
