### PR TITLE
Fixing Travis build

### DIFF
--- a/devtools/no-ops-conda/make_build.sh
+++ b/devtools/no-ops-conda/make_build.sh
@@ -3,13 +3,13 @@
 # Basic idea: get the requirements for OPS and put them in a file. Then have
 # conda install them.
 
-OPS_CONDA_RECIPE="https://raw.githubusercontent.com/choderalab/openpathsampling/master/devtools/conda-recipe"
+OPS_CONDA_RECIPE="https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda-recipe"
 MYDIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 curl ${OPS_CONDA_RECIPE}/meta.yaml | 
     grep "\ \ \ \ \-\ " | 
     sed 's/\ \ \ \ \-\ //' |
-    sed 's/\ .*//' |
+    #sed 's/\ .*//' |
     grep -v "openpathsampling" > ${MYDIR}/ops_reqs.txt
 
 cp ${MYDIR}/../conda-recipe/meta.yaml ${MYDIR}/meta.yaml

--- a/devtools/no-ops-conda/make_build.sh
+++ b/devtools/no-ops-conda/make_build.sh
@@ -10,6 +10,8 @@ curl ${OPS_CONDA_RECIPE}/meta.yaml |
     grep "\ \ \ \ \-\ " | 
     sed 's/\ \ \ \ \-\ //' |
     #sed 's/\ .*//' |
+    sed 's/\(.*\)\ /\1=/' |
+    sort | uniq |
     grep -v "openpathsampling" > ${MYDIR}/ops_reqs.txt
 
 cp ${MYDIR}/../conda-recipe/meta.yaml ${MYDIR}/meta.yaml

--- a/ops_piggybacker/one_way_tps_converters.py
+++ b/ops_piggybacker/one_way_tps_converters.py
@@ -32,6 +32,7 @@ import os
 import openpathsampling as paths
 import ops_piggybacker as oink
 from openpathsampling.engines.openmm.tools import ops_load_trajectory
+from openpathsampling.tools import refresh_output
 
 from collections import namedtuple
 
@@ -325,9 +326,8 @@ class OneWayTPSConverter(oink.ShootingPseudoSimulator):
         line_num = 0
         while line_num < n_steps:
             if self.report_progress is not None:
-                self.report_progress.write("Working on MC step " +
-                                           str(line_num) + "\n")
-                self.report_progress.flush()
+                refresh_output("Working on MC step " + str(line_num) + "\n",
+                               output_stream=self.report_progress)
 
             end = min(line_num + n_trajs_per_block, n_steps)
             block = lines[line_num:end]


### PR DESCRIPTION
This is failing because we strip the pinning from the OPS conda recipe -- this will replace that.

See also https://github.com/openpathsampling/openpathsampling/pull/655