### PR TITLE
Fix move summary

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ install:
     - popd
     - which pip
     - pip list
-    - conda install nose python-coveralls
+    - conda install nose coveralls
 
 script:
     - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
     - source devtools/ci/miniconda_install.sh
     - export PYTHONUNBUFFERED=true
     - conda config --set always_yes true
-    - conda config channels --add conda-forge
-    - conda config channels --add omnia
+    - conda config --add channels conda-forge
+    - conda config --add channels omnia
 
 install:
     # the next two are if the OPS conda build isn't working

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,17 @@
 language: python
 
-python:
-    - "2.7"
-
 install:
     - deactivate
-    - source devtools/ci/install_conda.sh
+    - source devtools/ci/miniconda_install.sh
     - export PYTHONUNBUFFERED=true
 
 script:
     - conda install --yes conda-build numpy
     - conda config --set always_yes true
+    - curl https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh | bash
     # the next two are if the OPS conda build isn't working
-    - source devtools/no-ops-conda/make_build.sh
-    - source devtools/no-ops-conda/build.sh
+    #- source devtools/no-ops-conda/make_build.sh
+    #- source devtools/no-ops-conda/build.sh
     # the next three are preferred if the OPS conda build is working
     #- conda build devtools/conda-recipe
     #- conda install --use-local ops_piggybacker-dev
@@ -28,7 +26,9 @@ after_success:
 
 env:
     matrix:
-        - python=2.7 CONDA_PY=27 CONDA_NPY=110
+        - CONDA_PY="2.7"
+        - CONDA_PY="3.6"
+        - CONDA_PY="3.7"
 # only run travis on master: either as PR (where the PR tests the merge with
 # master) or as a push (where the push is directly to master, as happens
 # when a PR is officially merged into master and pushed to GH)

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,10 @@ install:
     - export PYTHONUNBUFFERED=true
 
 script:
-    - conda install --yes conda-build numpy
+    #- conda install --yes conda-build numpy
     - conda config --set always_yes true
+    - conda config channels --add conda-forge
+    - conda config channels --add omnia
     - curl https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh | bash
     # the next two are if the OPS conda build isn't working
     #- source devtools/no-ops-conda/make_build.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ before_install:
     - conda config --add channels conda-forge
     - conda config --add channels omnia
     - conda create -q -y --name test conda pyyaml python=$CONDA_PY
-    - conda activate test
+    - source activate test
     - conda config --env --add pinned_packages python=$CONDA_PY
     - conda install pip
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,8 @@ install:
     - git clone https://github.com/openpathsampling/openpathsampling.git
     - cd openpathsampling && pip install -e . && cd ..
     - popd
+    - which pip
+    - pip list
     - conda install nose python-coveralls
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ before_install:
     - conda config --set always_yes true
     - conda config --add channels conda-forge
     - conda config --add channels omnia
+    - conda install pip
 
 install:
     # the next two are if the OPS conda build isn't working
@@ -25,7 +26,7 @@ install:
 
 script:
     - conda list
-    - python -c "import openpathsampling; print 'OPS version' + openpathsampling.version.full_version"
+    - python -c "from __future__ import print_function; import openpathsampling; print('OPS version' + openpathsampling.version.full_version)"
     - python ops_piggybacker/tests/common_test_data.py
     - nosetests -v --with-coverage
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ install:
     #- conda build devtools/conda-recipe
     #- conda install --use-local ops_piggybacker-dev
     - conda install -y -c conda-forge -c omnia openpathsampling
-    - conda unintall -y openpathsampling
+    - conda uninstall -y openpathsampling
     - pushd ~
     - git clone https://github.com/openpathsampling/openpathsampling.git
     - cd openpathsampling && pip install -e . && cd ..

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,12 @@ install:
     # the next three are preferred if the OPS conda build is working
     #- conda build devtools/conda-recipe
     #- conda install --use-local ops_piggybacker-dev
-    - curl https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh | bash
+    - conda install -y -c conda-forge -c omnia openpathsampling
+    - conda unintall -y openpathsampling
+    - pushd ~
+    - git clone https://github.com/openpathsampling/openpathsampling.git
+    - cd openpathsampling && pip install -e . && cd ..
+    - popd
     - conda install nose python-coveralls
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,9 @@ before_install:
     - conda config --set always_yes true
     - conda config --add channels conda-forge
     - conda config --add channels omnia
+    - conda create -q -y --name test conda pyyaml python=$CONDA_PY
+    - conda activate test
+    - conda config --env --add pinned_packages python=$CONDA_PY
     - conda install pip
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,21 @@
 language: python
 
-install:
+before_install:
     - deactivate
     - source devtools/ci/miniconda_install.sh
     - export PYTHONUNBUFFERED=true
-
-script:
-    #- conda install --yes conda-build numpy
     - conda config --set always_yes true
     - conda config channels --add conda-forge
     - conda config channels --add omnia
-    - curl https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh | bash
+
+install:
     # the next two are if the OPS conda build isn't working
     #- source devtools/no-ops-conda/make_build.sh
     #- source devtools/no-ops-conda/build.sh
     # the next three are preferred if the OPS conda build is working
     #- conda build devtools/conda-recipe
     #- conda install --use-local ops_piggybacker-dev
+    - curl https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh | bash
     - conda install nose python-coveralls
 
 script:

--- a/devtools/ci/miniconda_install.sh
+++ b/devtools/ci/miniconda_install.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+### Install Miniconda
+
+if [ -z "$CONDA_PY" ]
+then
+    CONDA_PY=3.7
+fi
+
+if [ -z "$OS_ARCH" ]
+then
+    OS_ARCH=Linux-x86_64
+fi
+
+# universal MD5 checker
+MD5_CMD=`basename $(command -v md5sum || command -v md5 || command -v openssl)`
+declare -A opts=( ["md5"]="-r" ["openssl"]="md5 -r" ["md5sum"]="" )
+MD5_OPT=" ${opts[$MD5_CMD]}"
+
+pyV=${CONDA_PY:0:1}
+conda_version="latest"
+#conda_version="4.4.10"  # can pin a miniconda version like this, if needed
+
+MINICONDA=Miniconda${pyV}-${conda_version}-${OS_ARCH}.sh
+MINICONDA_MD5=$(curl -s https://repo.continuum.io/miniconda/ | grep -A3 $MINICONDA | sed -n '4p' | sed -n 's/ *<td>\(.*\)<\/td> */\1/p')
+wget https://repo.continuum.io/miniconda/$MINICONDA
+SCRIPT_MD5=`eval "$MD5_CMD $MD5_OPT $MINICONDA" | cut -d ' ' -f 1`
+
+if [[ $MINICONDA_MD5 != $SCRIPT_MD5 ]]; then
+    echo "Miniconda MD5 mismatch"
+    echo "Expected: $MINICONDA_MD5"
+    echo "Found: $SCRIPT_MD5"
+    exit 1
+fi
+bash $MINICONDA -b -p $HOME/miniconda${pyV}
+
+export PATH=$HOME/miniconda${pyV}/bin:$PATH
+
+conda update --yes conda
+rm -f $MINICONDA

--- a/ops_environment.yml
+++ b/ops_environment.yml
@@ -1,7 +1,7 @@
 name: root
 channels:
+    - conda-forge
     - omnia
-    - http://conda.anaconda.org/omnia
     - defaults
 dependencies:
     - hdf5
@@ -11,7 +11,7 @@ dependencies:
     - numpy
     - mdtraj
     - openssl
-    - openpathsampling-dev
+    - openpathsampling
     - pandas
     - pip
     - pycosat

--- a/ops_piggybacker/__init__.py
+++ b/ops_piggybacker/__init__.py
@@ -1,5 +1,5 @@
-from mover_stubs import ShootingStub
-from simulation_stubs import ShootingPseudoSimulator
-from one_way_tps_converters import (
+from .mover_stubs import ShootingStub
+from .simulation_stubs import ShootingPseudoSimulator
+from .one_way_tps_converters import (
     TPSConverterOptions, OneWayTPSConverter, GromacsOneWayTPSConverter
 )

--- a/ops_piggybacker/mover_stubs.py
+++ b/ops_piggybacker/mover_stubs.py
@@ -134,7 +134,7 @@ class ShootingStub(paths.pathmover.PathMover):
         )
 
         trials = [trial]
-        # move_details = paths.MoveDetails()
+        # move_details = paths.Details()
 
         if accepted:
             inner = paths.AcceptedSampleMoveChange(
@@ -149,7 +149,7 @@ class ShootingStub(paths.pathmover.PathMover):
                 details=details
             )
 
-        rc_details = paths.MoveDetails()
+        rc_details = paths.Details()
         rc_details.inputs = []
         rc_details.choice = choice
         rc_details.chosen_mover = self.mimic.movers[choice]

--- a/ops_piggybacker/simulation_stubs.py
+++ b/ops_piggybacker/simulation_stubs.py
@@ -73,7 +73,7 @@ class ShootingPseudoSimulator(paths.PathSimulator):
             change = paths.PathSimulatorMoveChange(
                 subchange=subchange,
                 mover=self._path_sim_mover,
-                details=paths.MoveDetails(step=self.step)
+                details=paths.Details(step=self.step)
             )
             samples = change.results
             new_sampleset = self.sample_set.apply_samples(samples)

--- a/ops_piggybacker/tests/__init__.py
+++ b/ops_piggybacker/tests/__init__.py
@@ -1,2 +1,2 @@
 import openpathsampling
-import .tools
+from . import tools

--- a/ops_piggybacker/tests/__init__.py
+++ b/ops_piggybacker/tests/__init__.py
@@ -1,2 +1,2 @@
 import openpathsampling
-import tools
+import .tools

--- a/ops_piggybacker/tests/common_test_data.py
+++ b/ops_piggybacker/tests/common_test_data.py
@@ -1,4 +1,4 @@
-
+from __future__ import print_function
 import openpathsampling as paths
 from openpathsampling.tests.test_helpers import make_1d_traj
 import os
@@ -28,7 +28,7 @@ def shooting_move_info():
 
     # for traj in [t0, out1, out2, out3, out4]:
         # print [s.xyz[0][0] for s in traj]
-    
+
     # replica, full trial, shooting idx, one-way trial, direction
     moves = [
         (0, out1, 4, True, t1, -1),
@@ -51,11 +51,13 @@ if __name__ == "__main__":
     my_directory = os.path.dirname(__file__)
     tps_setup_filename = os.path.join(my_directory, "test_data",
                                       "tps_setup.nc")
-    print "Putting TPS setup in:", tps_setup_filename
+    print("Putting TPS setup in:", tps_setup_filename)
     # note that this assumes that this is the installed package location
     # (if this file is run from another copy, then there are two test_data/
     # directories to worry about here!)
-    tps_storage = paths.Storage(tps_setup_filename, "w", template)
+    tps_storage = paths.Storage(tps_setup_filename, mode="w",
+                                template=template)
+    tps_storage.save(template)
     tps_storage.save(tps_network)
     tps_storage.sync()
     tps_storage.close()

--- a/ops_piggybacker/tests/test_mover_stubs.py
+++ b/ops_piggybacker/tests/test_mover_stubs.py
@@ -4,13 +4,13 @@ import openpathsampling as paths
 from . import common_test_data as common
 from .tools import *
 
-class testNoEngine(object):
+class TestNoEngine(object):
     def test_init(self):
         # only test that it instantiates
         oink.mover_stubs.NoEngine()
 
 
-class testShootingStub(object):
+class TestShootingStub(object):
     def setup(self):
         # this instantiates an object, and ensures that instantiation works
         self.stub = oink.ShootingStub(common.tps_ensemble)
@@ -20,7 +20,7 @@ class testShootingStub(object):
     def test_join_one_way(self):
         moves = common.tps_shooting_moves
         initial = common.initial_tps_sample.trajectory
-        
+
         out_1 = moves[0][1]
         sp_1 = initial[moves[0][2]]
         trial_1 = moves[0][4]

--- a/ops_piggybacker/tests/test_one_way_tps_converters.py
+++ b/ops_piggybacker/tests/test_one_way_tps_converters.py
@@ -39,7 +39,7 @@ class StupidOneWayTPSConverter(oink.OneWayTPSConverter):
 
 
 class TestOneWayTPSConverter(object):
-    def setUp(self):
+    def setup(self):
         test_dir = "one_way_tps_examples"
         self.data_filename = lambda f : \
                 data_filename(os.path.join(test_dir, f))
@@ -58,7 +58,7 @@ class TestOneWayTPSConverter(object):
         )
         old_store.close()
 
-    def tearDown(self):
+    def teardown(self):
         try:
             self.converter.storage.close()
         except RuntimeError:
@@ -270,7 +270,7 @@ class TestOneWayTPSConverter(object):
             os.remove(storage_file)
 
 class TestGromacsOneWayTPSConverter(object):
-    def setUp(self):
+    def setup(self):
         from openpathsampling.engines.openmm.tools import ops_load_trajectory
         if not HAS_MDTRAJ:
             raise SkipTest("Missing MDTraj")
@@ -309,7 +309,7 @@ class TestGromacsOneWayTPSConverter(object):
         self.converter.report_progress = sys.stdout
         self.converter.n_trajs_per_block = 1
 
-    def tearDown(self):
+    def teardown(self):
         self.converter.storage.close()
         if os.path.exists(self.data_filename("gromacs.nc")):
             os.remove(self.data_filename("gromacs.nc"))

--- a/ops_piggybacker/tests/test_one_way_tps_converters.py
+++ b/ops_piggybacker/tests/test_one_way_tps_converters.py
@@ -194,7 +194,7 @@ class TestOneWayTPSConverter(object):
         # next is same as test_simulation_stubs  (move to a common test?)
         assert_equal(len(analysis.steps), 5) # initial + 4 steps
         scheme = analysis.schemes[0]
-        assert_equal(scheme.movers.keys(), ['shooting'])
+        assert_equal(list(scheme.movers.keys()), ['shooting'])
         assert_equal(len(scheme.movers['shooting']), 1)
         mover = scheme.movers['shooting'][0]
 
@@ -202,10 +202,12 @@ class TestOneWayTPSConverter(object):
         ## scheme.move_summary
         devnull = open(os.devnull, 'w')
         scheme.move_summary(analysis.steps, output=devnull)
-        mover_keys = [k for k in scheme._mover_acceptance.keys()
+        mover_keys = [k for k in scheme._mover_acceptance._trials.keys()
                       if k[0] == mover]
         assert_equal(len(mover_keys), 1)
-        assert_equal(scheme._mover_acceptance[mover_keys[0]], [3,4])
+        assert_equal(scheme._mover_acceptance._trials[mover_keys[0]], 4)
+        assert_equal(scheme._mover_acceptance._accepted[mover_keys[0]], 3)
+        # assert_equal(scheme._mover_acceptance[mover_keys[0]], [3,4])
 
         ## move history tree
         import openpathsampling.visualize as ops_vis

--- a/ops_piggybacker/tests/tools.py
+++ b/ops_piggybacker/tests/tools.py
@@ -1,8 +1,9 @@
 from nose.tools import (
-    assert_equal, assert_not_equal, assert_almost_equal, assert_items_equal,
-    raises, assert_true
+    assert_equal, assert_not_equal, assert_almost_equal, raises, assert_true
 )
 from nose.plugins.skip import Skip, SkipTest
+
+
 
 from numpy.testing import assert_array_almost_equal
 import numpy as np
@@ -13,6 +14,11 @@ from pkg_resources import resource_filename
 def data_filename(fname, subdir='test_data'):
     return resource_filename('ops_piggybacker',
                              os.path.join('tests', subdir, fname))
+
+def assert_items_equal(truth, beauty):
+    assert_equal(len(truth), len(beauty))
+    for (t, b) in zip(truth, beauty):
+        assert_equal(t, b)
 
 import logging
 logging.getLogger('openpathsampling.netcdfplus').setLevel(logging.CRITICAL)


### PR DESCRIPTION
Changes to the internals of the how OPS `MoveScheme._move_acceptance` attribute in https://github.com/openpathsampling/openpathsampling/pull/823 led to tests failing here (because the tests were against private contents). This PR fixes that.

While I'm at it, I'll update OPSPiggybacker to run on Python 3 and make it so the tests are pytest-compatible. Also updating to remove deprecation warnings from changes in OPS.