### PR TITLE
Use the OPS developer install for OPS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: python
 
 before_install:
     - deactivate
-    - source devtools/ci/miniconda_install.sh
     - export PYTHONUNBUFFERED=true
+    - source devtools/ci/miniconda_install.sh
     - conda config --set always_yes true
     - conda config --add channels omnia
     - conda config --add channels conda-forge
@@ -12,9 +12,8 @@ before_install:
     - conda config --env --add pinned_packages python=$CONDA_PY
 
 install:
-    - conda install -y -c conda-forge python=3.7 openmmtools  # DEBUG
     - curl -OLk https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh
-    - source conda_ops_dev_install.sh
+    - source conda_ops_dev_install.sh dwhswenson py37
     - conda install nose coveralls
     - pip install -e .
 
@@ -29,8 +28,8 @@ after_success:
 
 env:
     matrix:
-        #- CONDA_PY="2.7"
-        #- CONDA_PY="3.6"
+        - CONDA_PY="2.7"
+        - CONDA_PY="3.6"
         - CONDA_PY="3.7"
 # only run travis on master: either as PR (where the PR tests the merge with
 # master) or as a push (where the push is directly to master, as happens

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
 
 install:
     - curl -OLk https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh
-    - source conda_ops_dev_install.sh dwhswenson py37
+    - source conda_ops_dev_install.sh
     - conda install nose coveralls
     - pip install -e .
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ before_install:
     - source devtools/ci/miniconda_install.sh
     - export PYTHONUNBUFFERED=true
     - conda config --set always_yes true
-    - conda config --add channels conda-forge
     - conda config --add channels omnia
+    - conda config --add channels conda-forge
     - conda create -q -y --name test conda pyyaml pip python=$CONDA_PY
     - source activate test
     - conda config --env --add pinned_packages python=$CONDA_PY

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,27 +7,15 @@ before_install:
     - conda config --set always_yes true
     - conda config --add channels conda-forge
     - conda config --add channels omnia
-    - conda create -q -y --name test conda pyyaml python=$CONDA_PY
+    - conda create -q -y --name test conda pyyaml pip python=$CONDA_PY
     - source activate test
     - conda config --env --add pinned_packages python=$CONDA_PY
-    - conda install pip
 
 install:
-    # the next two are if the OPS conda build isn't working
-    #- source devtools/no-ops-conda/make_build.sh
-    #- source devtools/no-ops-conda/build.sh
-    # the next three are preferred if the OPS conda build is working
-    #- conda build devtools/conda-recipe
-    #- conda install --use-local ops_piggybacker-dev
-    - conda install -y -c conda-forge -c omnia openpathsampling
-    - conda uninstall -y openpathsampling
-    - pushd ~
-    - git clone https://github.com/openpathsampling/openpathsampling.git
-    - cd openpathsampling && pip install -e . && cd ..
-    - popd
-    - which pip
-    - pip list
+    - curl -OLk https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh
+    - source conda_ops_dev_install.sh
     - conda install nose coveralls
+    - pip install -e .
 
 script:
     - conda list

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ before_install:
     - conda config --env --add pinned_packages python=$CONDA_PY
 
 install:
+    - conda install -y -c conda-forge python=3.7 openmmtools  # DEBUG
     - curl -OLk https://raw.githubusercontent.com/openpathsampling/openpathsampling/master/devtools/conda_ops_dev_install.sh
     - source conda_ops_dev_install.sh
     - conda install nose coveralls
@@ -28,8 +29,8 @@ after_success:
 
 env:
     matrix:
-        - CONDA_PY="2.7"
-        - CONDA_PY="3.6"
+        #- CONDA_PY="2.7"
+        #- CONDA_PY="3.6"
         - CONDA_PY="3.7"
 # only run travis on master: either as PR (where the PR tests the merge with
 # master) or as a push (where the push is directly to master, as happens

--- a/setup.py
+++ b/setup.py
@@ -109,7 +109,7 @@ def buildKeywordDictionary():
     outputString=""
     firstTab     = 40
     secondTab    = 60
-    for key in sorted( setupKeywords.iterkeys() ):
+    for key in sorted( setupKeywords.keys() ):
          value         = setupKeywords[key]
          outputString += (key.rjust(firstTab)
                           + str(value).rjust(secondTab) + "\n")


### PR DESCRIPTION
Currently having Travis errors based on the OPS install. This PR switches us to the new centralized OPS developer install.